### PR TITLE
Just a little example of funcsharp

### DIFF
--- a/src/Marvin.Web/Code/FlatAreas/FlatAreaExpander.cs
+++ b/src/Marvin.Web/Code/FlatAreas/FlatAreaExpander.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.Controllers;
+﻿using FuncSharp;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Razor;
 
 // Modified from https://github.com/OdeToCode/AddFeatureFolders
@@ -9,9 +10,9 @@ namespace Marvin.Web
     {
         private readonly string _placeholder;
 
-        public FlatAreaExpander(FlatAreaOptions options)
+        public FlatAreaExpander(IOption<FlatAreaOptions> options)
         {
-            _placeholder = options?.AreaPlaceholder ?? throw new ArgumentNullException(nameof(options));
+            _placeholder = options.Match(o => o.AreaPlaceholder, e => throw new ArgumentNullException(nameof(options)));
         }
 
         public void PopulateValues(ViewLocationExpanderContext context)

--- a/src/Marvin.Web/Code/FlatAreas/FlatAreaExtensions.cs
+++ b/src/Marvin.Web/Code/FlatAreas/FlatAreaExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Modified from https://github.com/OdeToCode/AddFeatureFolders
 
+using FuncSharp;
+
 namespace Marvin.Web
 {
     public static class FlatAreaExtensions
@@ -18,7 +20,7 @@ namespace Marvin.Web
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var expander = new FlatAreaExpander(options);
+            var expander = new FlatAreaExpander(options.ToOption());
 
             services.AddMvcOptions(o =>
             {


### PR DESCRIPTION
Instead of having nullable references we can explicitly call it out using the `IOptions<T>` pattern.

Then it forces the developer to handle it and (apparently) reduces the null references exceptions ;-)

`Match` is basically going to return a CoProduct of `T` or of `Unit` (Unit is another way of saying no-thing)

Its not really necessary in this code file but I though to try it out here and give an example of how it works